### PR TITLE
Remove PLCrashReporter

### DIFF
--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo.Droid/Contoso.Forms.Demo.Droid.csproj
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo.Droid/Contoso.Forms.Demo.Droid.csproj
@@ -83,22 +83,22 @@
       <HintPath>..\..\..\packages\Xamarin.Forms.2.3.2.127\lib\MonoAndroid10\Xamarin.Forms.Xaml.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.Mobile.Android.Bindings">
-      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.0.2.2-SNAPSHOT\lib\MonoAndroid403\Microsoft.Azure.Mobile.Android.Bindings.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.0.3.0-SNAPSHOT\lib\MonoAndroid403\Microsoft.Azure.Mobile.Android.Bindings.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.Mobile">
-      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.0.2.2-SNAPSHOT\lib\MonoAndroid403\Microsoft.Azure.Mobile.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Azure.Mobile.Analytics.Android.Bindings">
-      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.Analytics.0.2.2-SNAPSHOT\lib\MonoAndroid403\Microsoft.Azure.Mobile.Analytics.Android.Bindings.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Azure.Mobile.Analytics">
-      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.Analytics.0.2.2-SNAPSHOT\lib\MonoAndroid403\Microsoft.Azure.Mobile.Analytics.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.0.3.0-SNAPSHOT\lib\MonoAndroid403\Microsoft.Azure.Mobile.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.Mobile.Crashes.Android.Bindings">
-      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.Crashes.0.2.2-SNAPSHOT\lib\MonoAndroid403\Microsoft.Azure.Mobile.Crashes.Android.Bindings.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.Crashes.0.3.0-SNAPSHOT\lib\MonoAndroid403\Microsoft.Azure.Mobile.Crashes.Android.Bindings.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.Mobile.Crashes">
-      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.Crashes.0.2.2-SNAPSHOT\lib\MonoAndroid403\Microsoft.Azure.Mobile.Crashes.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.Crashes.0.3.0-SNAPSHOT\lib\MonoAndroid403\Microsoft.Azure.Mobile.Crashes.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Azure.Mobile.Analytics.Android.Bindings">
+      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.Analytics.0.3.0-SNAPSHOT\lib\MonoAndroid403\Microsoft.Azure.Mobile.Analytics.Android.Bindings.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Azure.Mobile.Analytics">
+      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.Analytics.0.3.0-SNAPSHOT\lib\MonoAndroid403\Microsoft.Azure.Mobile.Analytics.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo.Droid/Contoso.Forms.Demo.Droid.csproj
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo.Droid/Contoso.Forms.Demo.Droid.csproj
@@ -83,22 +83,22 @@
       <HintPath>..\..\..\packages\Xamarin.Forms.2.3.2.127\lib\MonoAndroid10\Xamarin.Forms.Xaml.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.Mobile.Android.Bindings">
-      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.0.2.1\lib\MonoAndroid403\Microsoft.Azure.Mobile.Android.Bindings.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.0.2.2-SNAPSHOT\lib\MonoAndroid403\Microsoft.Azure.Mobile.Android.Bindings.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.Mobile">
-      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.0.2.1\lib\MonoAndroid403\Microsoft.Azure.Mobile.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Azure.Mobile.Crashes.Android.Bindings">
-      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.Crashes.0.2.1\lib\MonoAndroid403\Microsoft.Azure.Mobile.Crashes.Android.Bindings.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Azure.Mobile.Crashes">
-      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.Crashes.0.2.1\lib\MonoAndroid403\Microsoft.Azure.Mobile.Crashes.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.0.2.2-SNAPSHOT\lib\MonoAndroid403\Microsoft.Azure.Mobile.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.Mobile.Analytics.Android.Bindings">
-      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.Analytics.0.2.1\lib\MonoAndroid403\Microsoft.Azure.Mobile.Analytics.Android.Bindings.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.Analytics.0.2.2-SNAPSHOT\lib\MonoAndroid403\Microsoft.Azure.Mobile.Analytics.Android.Bindings.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.Mobile.Analytics">
-      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.Analytics.0.2.1\lib\MonoAndroid403\Microsoft.Azure.Mobile.Analytics.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.Analytics.0.2.2-SNAPSHOT\lib\MonoAndroid403\Microsoft.Azure.Mobile.Analytics.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Azure.Mobile.Crashes.Android.Bindings">
+      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.Crashes.0.2.2-SNAPSHOT\lib\MonoAndroid403\Microsoft.Azure.Mobile.Crashes.Android.Bindings.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Azure.Mobile.Crashes">
+      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.Crashes.0.2.2-SNAPSHOT\lib\MonoAndroid403\Microsoft.Azure.Mobile.Crashes.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo.Droid/packages.config
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo.Droid/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Azure.Mobile" version="0.2.1" targetFramework="monoandroid70" />
-  <package id="Microsoft.Azure.Mobile.Analytics" version="0.2.1" targetFramework="monoandroid70" />
-  <package id="Microsoft.Azure.Mobile.Crashes" version="0.2.1" targetFramework="monoandroid70" />
+  <package id="Microsoft.Azure.Mobile" version="0.2.2-SNAPSHOT" targetFramework="monoandroid70" />
+  <package id="Microsoft.Azure.Mobile.Analytics" version="0.2.2-SNAPSHOT" targetFramework="monoandroid70" />
+  <package id="Microsoft.Azure.Mobile.Crashes" version="0.2.2-SNAPSHOT" targetFramework="monoandroid70" />
   <package id="Xamarin.Android.Support.Animated.Vector.Drawable" version="23.3.0" targetFramework="monoandroid70" />
   <package id="Xamarin.Android.Support.Design" version="23.3.0" targetFramework="monoandroid70" />
   <package id="Xamarin.Android.Support.v4" version="23.3.0" targetFramework="monoandroid70" />

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo.Droid/packages.config
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo.Droid/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Azure.Mobile" version="0.2.2-SNAPSHOT" targetFramework="monoandroid70" />
-  <package id="Microsoft.Azure.Mobile.Analytics" version="0.2.2-SNAPSHOT" targetFramework="monoandroid70" />
-  <package id="Microsoft.Azure.Mobile.Crashes" version="0.2.2-SNAPSHOT" targetFramework="monoandroid70" />
+  <package id="Microsoft.Azure.Mobile" version="0.3.0-SNAPSHOT" targetFramework="monoandroid70" />
+  <package id="Microsoft.Azure.Mobile.Analytics" version="0.3.0-SNAPSHOT" targetFramework="monoandroid70" />
+  <package id="Microsoft.Azure.Mobile.Crashes" version="0.3.0-SNAPSHOT" targetFramework="monoandroid70" />
   <package id="Xamarin.Android.Support.Animated.Vector.Drawable" version="23.3.0" targetFramework="monoandroid70" />
   <package id="Xamarin.Android.Support.Design" version="23.3.0" targetFramework="monoandroid70" />
   <package id="Xamarin.Android.Support.v4" version="23.3.0" targetFramework="monoandroid70" />

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo.iOS/Contoso.Forms.Demo.iOS.csproj
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo.iOS/Contoso.Forms.Demo.iOS.csproj
@@ -102,22 +102,22 @@
       <HintPath>..\..\..\packages\Xamarin.Forms.2.3.2.127\lib\Xamarin.iOS10\Xamarin.Forms.Xaml.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.Mobile">
-      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.0.2.2-SNAPSHOT\lib\Xamarin.iOS10\Microsoft.Azure.Mobile.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.0.3.0-SNAPSHOT\lib\Xamarin.iOS10\Microsoft.Azure.Mobile.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.Mobile.iOS.Bindings">
-      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.0.2.2-SNAPSHOT\lib\Xamarin.iOS10\Microsoft.Azure.Mobile.iOS.Bindings.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Azure.Mobile.Crashes">
-      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.Crashes.0.2.2-SNAPSHOT\lib\Xamarin.iOS10\Microsoft.Azure.Mobile.Crashes.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Azure.Mobile.Crashes.iOS.Bindings">
-      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.Crashes.0.2.2-SNAPSHOT\lib\Xamarin.iOS10\Microsoft.Azure.Mobile.Crashes.iOS.Bindings.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.0.3.0-SNAPSHOT\lib\Xamarin.iOS10\Microsoft.Azure.Mobile.iOS.Bindings.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.Mobile.Analytics">
-      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.Analytics.0.2.2-SNAPSHOT\lib\Xamarin.iOS10\Microsoft.Azure.Mobile.Analytics.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.Analytics.0.3.0-SNAPSHOT\lib\Xamarin.iOS10\Microsoft.Azure.Mobile.Analytics.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.Mobile.Analytics.iOS.Bindings">
-      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.Analytics.0.2.2-SNAPSHOT\lib\Xamarin.iOS10\Microsoft.Azure.Mobile.Analytics.iOS.Bindings.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.Analytics.0.3.0-SNAPSHOT\lib\Xamarin.iOS10\Microsoft.Azure.Mobile.Analytics.iOS.Bindings.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Azure.Mobile.Crashes">
+      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.Crashes.0.3.0-SNAPSHOT\lib\Xamarin.iOS10\Microsoft.Azure.Mobile.Crashes.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Azure.Mobile.Crashes.iOS.Bindings">
+      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.Crashes.0.3.0-SNAPSHOT\lib\Xamarin.iOS10\Microsoft.Azure.Mobile.Crashes.iOS.Bindings.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo.iOS/Contoso.Forms.Demo.iOS.csproj
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo.iOS/Contoso.Forms.Demo.iOS.csproj
@@ -102,22 +102,22 @@
       <HintPath>..\..\..\packages\Xamarin.Forms.2.3.2.127\lib\Xamarin.iOS10\Xamarin.Forms.Xaml.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.Mobile">
-      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.0.2.1\lib\Xamarin.iOS10\Microsoft.Azure.Mobile.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.0.2.2-SNAPSHOT\lib\Xamarin.iOS10\Microsoft.Azure.Mobile.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.Mobile.iOS.Bindings">
-      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.0.2.1\lib\Xamarin.iOS10\Microsoft.Azure.Mobile.iOS.Bindings.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Azure.Mobile.Analytics">
-      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.Analytics.0.2.1\lib\Xamarin.iOS10\Microsoft.Azure.Mobile.Analytics.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Azure.Mobile.Analytics.iOS.Bindings">
-      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.Analytics.0.2.1\lib\Xamarin.iOS10\Microsoft.Azure.Mobile.Analytics.iOS.Bindings.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.0.2.2-SNAPSHOT\lib\Xamarin.iOS10\Microsoft.Azure.Mobile.iOS.Bindings.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.Mobile.Crashes">
-      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.Crashes.0.2.1\lib\Xamarin.iOS10\Microsoft.Azure.Mobile.Crashes.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.Crashes.0.2.2-SNAPSHOT\lib\Xamarin.iOS10\Microsoft.Azure.Mobile.Crashes.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.Mobile.Crashes.iOS.Bindings">
-      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.Crashes.0.2.1\lib\Xamarin.iOS10\Microsoft.Azure.Mobile.Crashes.iOS.Bindings.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.Crashes.0.2.2-SNAPSHOT\lib\Xamarin.iOS10\Microsoft.Azure.Mobile.Crashes.iOS.Bindings.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Azure.Mobile.Analytics">
+      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.Analytics.0.2.2-SNAPSHOT\lib\Xamarin.iOS10\Microsoft.Azure.Mobile.Analytics.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Azure.Mobile.Analytics.iOS.Bindings">
+      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.Analytics.0.2.2-SNAPSHOT\lib\Xamarin.iOS10\Microsoft.Azure.Mobile.Analytics.iOS.Bindings.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -139,7 +139,6 @@
     <None Include="Entitlements.plist" />
     <None Include="icon_attribution.txt" />
     <None Include="packages.config" />
-    <None Include="MobileCenterFrameworks\CrashReporter.framework\CrashReporter" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Main.cs" />

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo.iOS/packages.config
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo.iOS/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Azure.Mobile" version="0.2.1" targetFramework="xamarinios10" />
-  <package id="Microsoft.Azure.Mobile.Analytics" version="0.2.1" targetFramework="xamarinios10" />
-  <package id="Microsoft.Azure.Mobile.Crashes" version="0.2.1" targetFramework="xamarinios10" />
+  <package id="Microsoft.Azure.Mobile" version="0.2.2-SNAPSHOT" targetFramework="xamarinios10" />
+  <package id="Microsoft.Azure.Mobile.Analytics" version="0.2.2-SNAPSHOT" targetFramework="xamarinios10" />
+  <package id="Microsoft.Azure.Mobile.Crashes" version="0.2.2-SNAPSHOT" targetFramework="xamarinios10" />
   <package id="Xamarin.Forms" version="2.3.2.127" targetFramework="xamarinios10" />
 </packages>

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo.iOS/packages.config
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo.iOS/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Azure.Mobile" version="0.2.2-SNAPSHOT" targetFramework="xamarinios10" />
-  <package id="Microsoft.Azure.Mobile.Analytics" version="0.2.2-SNAPSHOT" targetFramework="xamarinios10" />
-  <package id="Microsoft.Azure.Mobile.Crashes" version="0.2.2-SNAPSHOT" targetFramework="xamarinios10" />
+  <package id="Microsoft.Azure.Mobile" version="0.3.0-SNAPSHOT" targetFramework="xamarinios10" />
+  <package id="Microsoft.Azure.Mobile.Analytics" version="0.3.0-SNAPSHOT" targetFramework="xamarinios10" />
+  <package id="Microsoft.Azure.Mobile.Crashes" version="0.3.0-SNAPSHOT" targetFramework="xamarinios10" />
   <package id="Xamarin.Forms" version="2.3.2.127" targetFramework="xamarinios10" />
 </packages>

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/Contoso.Forms.Demo.csproj
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/Contoso.Forms.Demo.csproj
@@ -85,13 +85,13 @@
       <HintPath>..\..\..\packages\Xamarin.Forms.2.3.2.127\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.Xaml.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.Mobile">
-      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.0.2.1\lib\portable-net45+wp8+wpa81+win8+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Microsoft.Azure.Mobile.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Azure.Mobile.Analytics">
-      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.Analytics.0.2.1\lib\portable-net45+wp8+wpa81+win8+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Microsoft.Azure.Mobile.Analytics.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.0.2.2-SNAPSHOT\lib\portable-net45+wp8+wpa81+win8+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Microsoft.Azure.Mobile.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.Mobile.Crashes">
-      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.Crashes.0.2.1\lib\portable-net45+wp8+wpa81+win8+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Microsoft.Azure.Mobile.Crashes.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.Crashes.0.2.2-SNAPSHOT\lib\portable-net45+wp8+wpa81+win8+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Microsoft.Azure.Mobile.Crashes.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Azure.Mobile.Analytics">
+      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.Analytics.0.2.2-SNAPSHOT\lib\portable-net45+wp8+wpa81+win8+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Microsoft.Azure.Mobile.Analytics.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/Contoso.Forms.Demo.csproj
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/Contoso.Forms.Demo.csproj
@@ -85,13 +85,13 @@
       <HintPath>..\..\..\packages\Xamarin.Forms.2.3.2.127\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.Xaml.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.Mobile">
-      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.0.2.2-SNAPSHOT\lib\portable-net45+wp8+wpa81+win8+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Microsoft.Azure.Mobile.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Azure.Mobile.Crashes">
-      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.Crashes.0.2.2-SNAPSHOT\lib\portable-net45+wp8+wpa81+win8+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Microsoft.Azure.Mobile.Crashes.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.0.3.0-SNAPSHOT\lib\portable-net45+wp8+wpa81+win8+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Microsoft.Azure.Mobile.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.Mobile.Analytics">
-      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.Analytics.0.2.2-SNAPSHOT\lib\portable-net45+wp8+wpa81+win8+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Microsoft.Azure.Mobile.Analytics.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.Analytics.0.3.0-SNAPSHOT\lib\portable-net45+wp8+wpa81+win8+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Microsoft.Azure.Mobile.Analytics.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Azure.Mobile.Crashes">
+      <HintPath>..\..\..\packages\Microsoft.Azure.Mobile.Crashes.0.3.0-SNAPSHOT\lib\portable-net45+wp8+wpa81+win8+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Microsoft.Azure.Mobile.Crashes.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/packages.config
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Azure.Mobile" version="0.2.1" targetFramework="portable45-net45+win8+wp8+wpa81" />
-  <package id="Microsoft.Azure.Mobile.Analytics" version="0.2.1" targetFramework="portable45-net45+win8+wp8+wpa81" />
-  <package id="Microsoft.Azure.Mobile.Crashes" version="0.2.1" targetFramework="portable45-net45+win8+wp8+wpa81" />
+  <package id="Microsoft.Azure.Mobile" version="0.2.2-SNAPSHOT" targetFramework="portable45-net45+win8+wp8+wpa81" />
+  <package id="Microsoft.Azure.Mobile.Analytics" version="0.2.2-SNAPSHOT" targetFramework="portable45-net45+win8+wp8+wpa81" />
+  <package id="Microsoft.Azure.Mobile.Crashes" version="0.2.2-SNAPSHOT" targetFramework="portable45-net45+win8+wp8+wpa81" />
   <package id="Xamarin.Forms" version="2.3.2.127" targetFramework="portable45-net45+win8+wp8+wpa81" />
 </packages>

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/packages.config
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Azure.Mobile" version="0.2.2-SNAPSHOT" targetFramework="portable45-net45+win8+wp8+wpa81" />
-  <package id="Microsoft.Azure.Mobile.Analytics" version="0.2.2-SNAPSHOT" targetFramework="portable45-net45+win8+wp8+wpa81" />
-  <package id="Microsoft.Azure.Mobile.Crashes" version="0.2.2-SNAPSHOT" targetFramework="portable45-net45+win8+wp8+wpa81" />
+  <package id="Microsoft.Azure.Mobile" version="0.3.0-SNAPSHOT" targetFramework="portable45-net45+win8+wp8+wpa81" />
+  <package id="Microsoft.Azure.Mobile.Analytics" version="0.3.0-SNAPSHOT" targetFramework="portable45-net45+win8+wp8+wpa81" />
+  <package id="Microsoft.Azure.Mobile.Crashes" version="0.3.0-SNAPSHOT" targetFramework="portable45-net45+win8+wp8+wpa81" />
   <package id="Xamarin.Forms" version="2.3.2.127" targetFramework="portable45-net45+win8+wp8+wpa81" />
 </packages>

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.iOS/Contoso.Forms.Puppet.iOS.csproj
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.iOS/Contoso.Forms.Puppet.iOS.csproj
@@ -152,6 +152,14 @@
       <Project>{4936A94C-BE22-4F73-8468-64FA4371FF80}</Project>
       <Name>Microsoft.Azure.Mobile.Crashes.iOS</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\..\SDK\MobileCenterCrashes\Microsoft.Azure.Mobile.Crashes.iOS.Bindings\Microsoft.Azure.Mobile.Crashes.iOS.Bindings.csproj">
+      <Project>{FCEB9729-627A-4964-B853-1649CA1FA76D}</Project>
+      <Name>Microsoft.Azure.Mobile.Crashes.iOS.Bindings</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\SDK\MobileCenter\Microsoft.Azure.Mobile.iOS.Bindings\Microsoft.Azure.Mobile.iOS.Bindings.csproj">
+      <Project>{5490FECC-63B2-4543-B4FE-EDD8D1BD8351}</Project>
+      <Name>Microsoft.Azure.Mobile.iOS.Bindings</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <Import Project="..\packages\Xamarin.Forms.2.3.2.127\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.2.3.2.127\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets')" />

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.iOS/Contoso.Forms.Puppet.iOS.csproj
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.iOS/Contoso.Forms.Puppet.iOS.csproj
@@ -148,17 +148,9 @@
       <Project>{B87370CD-AF51-45E0-AA15-3E0ABC0C30A0}</Project>
       <Name>Microsoft.Azure.Mobile.iOS</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\..\SDK\MobileCenter\Microsoft.Azure.Mobile.iOS.Bindings\Microsoft.Azure.Mobile.iOS.Bindings.csproj">
-      <Project>{5490FECC-63B2-4543-B4FE-EDD8D1BD8351}</Project>
-      <Name>Microsoft.Azure.Mobile.iOS.Bindings</Name>
-    </ProjectReference>
     <ProjectReference Include="..\..\..\SDK\MobileCenterCrashes\Microsoft.Azure.Mobile.Crashes.iOS\Microsoft.Azure.Mobile.Crashes.iOS.csproj">
       <Project>{4936A94C-BE22-4F73-8468-64FA4371FF80}</Project>
       <Name>Microsoft.Azure.Mobile.Crashes.iOS</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\..\SDK\MobileCenterCrashes\Microsoft.Azure.Mobile.Crashes.iOS.Bindings\Microsoft.Azure.Mobile.Crashes.iOS.Bindings.csproj">
-      <Project>{FCEB9729-627A-4964-B853-1649CA1FA76D}</Project>
-      <Name>Microsoft.Azure.Mobile.Crashes.iOS.Bindings</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/Contoso.Forms.Puppet.csproj
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/Contoso.Forms.Puppet.csproj
@@ -95,6 +95,20 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\SDK\MobileCenterAnalytics\Microsoft.Azure.Mobile.Analytics\Microsoft.Azure.Mobile.Analytics.csproj">
+      <Project>{0F13E444-717E-460A-BDE7-8AD537F0A418}</Project>
+      <Name>Microsoft.Azure.Mobile.Analytics</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\SDK\MobileCenterCrashes\Microsoft.Azure.Mobile.Crashes\Microsoft.Azure.Mobile.Crashes.csproj">
+      <Project>{302F0881-77AE-4CCE-ACF4-930AD5D4FB08}</Project>
+      <Name>Microsoft.Azure.Mobile.Crashes</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\SDK\MobileCenter\Microsoft.Azure.Mobile\Microsoft.Azure.Mobile.csproj">
+      <Project>{3FE04B97-48DE-4895-8612-ECBDFEBD917C}</Project>
+      <Name>Microsoft.Azure.Mobile</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Import Project="..\packages\Xamarin.Forms.2.3.1.114\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.2.3.1.114\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets')" />
   <Import Project="..\packages\Xamarin.Forms.2.3.2.127\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.2.3.2.127\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets')" />

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/Contoso.Forms.Puppet.csproj
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/Contoso.Forms.Puppet.csproj
@@ -95,20 +95,6 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\SDK\MobileCenterCrashes\Microsoft.Azure.Mobile.Crashes\Microsoft.Azure.Mobile.Crashes.csproj">
-      <Project>{302F0881-77AE-4CCE-ACF4-930AD5D4FB08}</Project>
-      <Name>Microsoft.Azure.Mobile.Crashes</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\..\SDK\MobileCenterAnalytics\Microsoft.Azure.Mobile.Analytics\Microsoft.Azure.Mobile.Analytics.csproj">
-      <Project>{0F13E444-717E-460A-BDE7-8AD537F0A418}</Project>
-      <Name>Microsoft.Azure.Mobile.Analytics</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\..\SDK\MobileCenter\Microsoft.Azure.Mobile\Microsoft.Azure.Mobile.csproj">
-      <Project>{3FE04B97-48DE-4895-8612-ECBDFEBD917C}</Project>
-      <Name>Microsoft.Azure.Mobile</Name>
-    </ProjectReference>
-  </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Import Project="..\packages\Xamarin.Forms.2.3.1.114\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.2.3.1.114\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets')" />
   <Import Project="..\packages\Xamarin.Forms.2.3.2.127\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.2.3.2.127\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets')" />

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/ModulePages/CrashesContentPage.xaml.cs
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/ModulePages/CrashesContentPage.xaml.cs
@@ -10,7 +10,6 @@ namespace Contoso.Forms.Puppet
         public CrashesContentPage()
         {
             InitializeComponent();
-            CrashesEnabledSwitchCell.On = Crashes.Enabled;
             if (Device.OS == TargetPlatform.iOS)
             {
                 Icon = "socket.png";

--- a/NuGetSpec/MobileCenterCrashes.nuspec
+++ b/NuGetSpec/MobileCenterCrashes.nuspec
@@ -26,7 +26,5 @@
     <file src="SDK/MobileCenterCrashes/Microsoft.Azure.Mobile.Crashes.iOS/bin/Release/Microsoft.Azure.Mobile.Crashes.dll" target="lib/Xamarin.iOS10/Microsoft.Azure.Mobile.Crashes.dll" />
     <file src="SDK/MobileCenterCrashes/Microsoft.Azure.Mobile.Crashes.iOS.Bindings/bin/Release/Microsoft.Azure.Mobile.Crashes.iOS.Bindings.dll" target="lib/Xamarin.iOS10/Microsoft.Azure.Mobile.Crashes.iOS.Bindings.dll" />
 
-    <file src="externals/ios/CrashReporter.framework/**" target="content/Xamarin.iOS10/MobileCenterFrameworks/CrashReporter.framework" />
-
   </files>
 </package>

--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ Multiplatform Xamarin.Forms app has three projects in your solution - portable c
 
 Now that you've integrated the SDK in your application, it's time to start the SDK and make use of Mobile Center services.
 
+** Note: If you installed the "Mobile Center Crashes" package for iOS prior to version 0.3.0, your iOS project should contain the folder
+"MobileCenterFrameworks" and its contents. It is no longer required, and safe to delete.**
+
 ## 4. Start the SDK
 
 To start the SDK in your app, follow these steps:

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ Multiplatform Xamarin.Forms app has three projects in your solution - portable c
 
 Now that you've integrated the SDK in your application, it's time to start the SDK and make use of Mobile Center services.
 
-** Note: If you installed the "Mobile Center Crashes" package for iOS prior to version 0.3.0, your iOS project should contain the folder
-"MobileCenterFrameworks" and its contents. It is no longer required, and safe to delete.**
+**Note:** If you installed the "Mobile Center Crashes" package for iOS prior to version 0.3.0, your iOS project should contain the folder
+"MobileCenterFrameworks" and its contents. It is no longer required and safe to delete.
 
 ## 4. Start the SDK
 

--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.Android.Bindings/Properties/AssemblyInfo.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.Android.Bindings/Properties/AssemblyInfo.cs
@@ -25,5 +25,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("0.2.2.0")]
-[assembly: AssemblyInformationalVersion("0.2.2-SNAPSHOT")]
+[assembly: AssemblyFileVersion(".0")]
+[assembly: AssemblyInformationalVersion("-SNAPSHOT")]

--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.Android.Bindings/Properties/AssemblyInfo.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.Android.Bindings/Properties/AssemblyInfo.cs
@@ -25,5 +25,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion(".0")]
-[assembly: AssemblyInformationalVersion("-SNAPSHOT")]
+[assembly: AssemblyFileVersion("0.3.0.0")]
+[assembly: AssemblyInformationalVersion("0.3.0-SNAPSHOT")]

--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.Android/Properties/AssemblyInfo.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.Android/Properties/AssemblyInfo.cs
@@ -25,5 +25,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("0.2.2.0")]
-[assembly: AssemblyInformationalVersion("0.2.2-SNAPSHOT")]
+[assembly: AssemblyFileVersion(".0")]
+[assembly: AssemblyInformationalVersion("-SNAPSHOT")]

--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.Android/Properties/AssemblyInfo.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.Android/Properties/AssemblyInfo.cs
@@ -25,5 +25,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion(".0")]
-[assembly: AssemblyInformationalVersion("-SNAPSHOT")]
+[assembly: AssemblyFileVersion("0.3.0.0")]
+[assembly: AssemblyInformationalVersion("0.3.0-SNAPSHOT")]

--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.iOS.Bindings/Microsoft.Azure.Mobile.iOS.Bindings.csproj
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.iOS.Bindings/Microsoft.Azure.Mobile.iOS.Bindings.csproj
@@ -20,7 +20,7 @@
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CustomCommands>
-      <CustomCommands>
+    <CustomCommands>
         <Command>
           <type>BeforeBuild</type>
           <command>sh ./build.sh -t externals-ios</command>

--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.iOS/Properties/AssemblyInfo.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.iOS/Properties/AssemblyInfo.cs
@@ -24,5 +24,5 @@ using System.Runtime.CompilerServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion(".0")]
-[assembly: AssemblyInformationalVersion("-SNAPSHOT")]
+[assembly: AssemblyFileVersion("0.3.0.0")]
+[assembly: AssemblyInformationalVersion("0.3.0-SNAPSHOT")]

--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.iOS/Properties/AssemblyInfo.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.iOS/Properties/AssemblyInfo.cs
@@ -24,5 +24,5 @@ using System.Runtime.CompilerServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("0.2.2.0")]
-[assembly: AssemblyInformationalVersion("0.2.2-SNAPSHOT")]
+[assembly: AssemblyFileVersion(".0")]
+[assembly: AssemblyInformationalVersion("-SNAPSHOT")]

--- a/SDK/MobileCenter/Microsoft.Azure.Mobile/Properties/AssemblyInfo.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile/Properties/AssemblyInfo.cs
@@ -25,5 +25,5 @@ using System.Resources;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("0.2.2.0")]
-[assembly: AssemblyInformationalVersion("0.2.2-SNAPSHOT")]
+[assembly: AssemblyFileVersion(".0")]
+[assembly: AssemblyInformationalVersion("-SNAPSHOT")]

--- a/SDK/MobileCenter/Microsoft.Azure.Mobile/Properties/AssemblyInfo.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile/Properties/AssemblyInfo.cs
@@ -25,5 +25,5 @@ using System.Resources;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion(".0")]
-[assembly: AssemblyInformationalVersion("-SNAPSHOT")]
+[assembly: AssemblyFileVersion("0.3.0.0")]
+[assembly: AssemblyInformationalVersion("0.3.0-SNAPSHOT")]

--- a/SDK/MobileCenterAnalytics/Microsoft.Azure.Mobile.Analytics.Android/Properties/AssemblyInfo.cs
+++ b/SDK/MobileCenterAnalytics/Microsoft.Azure.Mobile.Analytics.Android/Properties/AssemblyInfo.cs
@@ -25,5 +25,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("0.2.2.0")]
-[assembly: AssemblyInformationalVersion("0.2.2-SNAPSHOT")]
+[assembly: AssemblyFileVersion(".0")]
+[assembly: AssemblyInformationalVersion("-SNAPSHOT")]

--- a/SDK/MobileCenterAnalytics/Microsoft.Azure.Mobile.Analytics.Android/Properties/AssemblyInfo.cs
+++ b/SDK/MobileCenterAnalytics/Microsoft.Azure.Mobile.Analytics.Android/Properties/AssemblyInfo.cs
@@ -25,5 +25,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion(".0")]
-[assembly: AssemblyInformationalVersion("-SNAPSHOT")]
+[assembly: AssemblyFileVersion("0.3.0.0")]
+[assembly: AssemblyInformationalVersion("0.3.0-SNAPSHOT")]

--- a/SDK/MobileCenterAnalytics/Microsoft.Azure.Mobile.Analytics.iOS/Properties/AssemblyInfo.cs
+++ b/SDK/MobileCenterAnalytics/Microsoft.Azure.Mobile.Analytics.iOS/Properties/AssemblyInfo.cs
@@ -24,5 +24,5 @@ using System.Runtime.CompilerServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion(".0")]
-[assembly: AssemblyInformationalVersion("-SNAPSHOT")]
+[assembly: AssemblyFileVersion("0.3.0.0")]
+[assembly: AssemblyInformationalVersion("0.3.0-SNAPSHOT")]

--- a/SDK/MobileCenterAnalytics/Microsoft.Azure.Mobile.Analytics.iOS/Properties/AssemblyInfo.cs
+++ b/SDK/MobileCenterAnalytics/Microsoft.Azure.Mobile.Analytics.iOS/Properties/AssemblyInfo.cs
@@ -24,5 +24,5 @@ using System.Runtime.CompilerServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("0.2.2.0")]
-[assembly: AssemblyInformationalVersion("0.2.2-SNAPSHOT")]
+[assembly: AssemblyFileVersion(".0")]
+[assembly: AssemblyInformationalVersion("-SNAPSHOT")]

--- a/SDK/MobileCenterAnalytics/Microsoft.Azure.Mobile.Analytics/Properties/AssemblyInfo.cs
+++ b/SDK/MobileCenterAnalytics/Microsoft.Azure.Mobile.Analytics/Properties/AssemblyInfo.cs
@@ -25,5 +25,5 @@ using System.Reflection;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("0.2.2.0")]
-[assembly: AssemblyInformationalVersion("0.2.2-SNAPSHOT")]
+[assembly: AssemblyFileVersion(".0")]
+[assembly: AssemblyInformationalVersion("-SNAPSHOT")]

--- a/SDK/MobileCenterAnalytics/Microsoft.Azure.Mobile.Analytics/Properties/AssemblyInfo.cs
+++ b/SDK/MobileCenterAnalytics/Microsoft.Azure.Mobile.Analytics/Properties/AssemblyInfo.cs
@@ -25,5 +25,5 @@ using System.Reflection;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion(".0")]
-[assembly: AssemblyInformationalVersion("-SNAPSHOT")]
+[assembly: AssemblyFileVersion("0.3.0.0")]
+[assembly: AssemblyInformationalVersion("0.3.0-SNAPSHOT")]

--- a/SDK/MobileCenterCrashes/Microsoft.Azure.Mobile.Crashes.Android/Properties/AssemblyInfo.cs
+++ b/SDK/MobileCenterCrashes/Microsoft.Azure.Mobile.Crashes.Android/Properties/AssemblyInfo.cs
@@ -25,5 +25,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("0.2.2.0")]
-[assembly: AssemblyInformationalVersion("0.2.2-SNAPSHOT")]
+[assembly: AssemblyFileVersion(".0")]
+[assembly: AssemblyInformationalVersion("-SNAPSHOT")]

--- a/SDK/MobileCenterCrashes/Microsoft.Azure.Mobile.Crashes.Android/Properties/AssemblyInfo.cs
+++ b/SDK/MobileCenterCrashes/Microsoft.Azure.Mobile.Crashes.Android/Properties/AssemblyInfo.cs
@@ -25,5 +25,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion(".0")]
-[assembly: AssemblyInformationalVersion("-SNAPSHOT")]
+[assembly: AssemblyFileVersion("0.3.0.0")]
+[assembly: AssemblyInformationalVersion("0.3.0-SNAPSHOT")]

--- a/SDK/MobileCenterCrashes/Microsoft.Azure.Mobile.Crashes.iOS.Bindings/Microsoft.Azure.Mobile.Crashes.iOS.Bindings.csproj
+++ b/SDK/MobileCenterCrashes/Microsoft.Azure.Mobile.Crashes.iOS.Bindings/Microsoft.Azure.Mobile.Crashes.iOS.Bindings.csproj
@@ -51,7 +51,7 @@
     <NativeReference Include="..\..\..\externals\ios\MobileCenterCrashes.a">
       <Kind>Static</Kind>
       <ForceLoad>True</ForceLoad>
-      <Frameworks>./MobileCenterFrameworks/CrashReporter.framework</Frameworks>
+      <Frameworks></Frameworks>
       <LinkerFlags>-lc++</LinkerFlags>
 	  <IsCxx>True</IsCxx>
     </NativeReference>

--- a/SDK/MobileCenterCrashes/Microsoft.Azure.Mobile.Crashes.iOS/Properties/AssemblyInfo.cs
+++ b/SDK/MobileCenterCrashes/Microsoft.Azure.Mobile.Crashes.iOS/Properties/AssemblyInfo.cs
@@ -24,5 +24,5 @@ using System.Runtime.CompilerServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion(".0")]
-[assembly: AssemblyInformationalVersion("-SNAPSHOT")]
+[assembly: AssemblyFileVersion("0.3.0.0")]
+[assembly: AssemblyInformationalVersion("0.3.0-SNAPSHOT")]

--- a/SDK/MobileCenterCrashes/Microsoft.Azure.Mobile.Crashes.iOS/Properties/AssemblyInfo.cs
+++ b/SDK/MobileCenterCrashes/Microsoft.Azure.Mobile.Crashes.iOS/Properties/AssemblyInfo.cs
@@ -24,5 +24,5 @@ using System.Runtime.CompilerServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("0.2.2.0")]
-[assembly: AssemblyInformationalVersion("0.2.2-SNAPSHOT")]
+[assembly: AssemblyFileVersion(".0")]
+[assembly: AssemblyInformationalVersion("-SNAPSHOT")]

--- a/SDK/MobileCenterCrashes/Microsoft.Azure.Mobile.Crashes/Properties/AssemblyInfo.cs
+++ b/SDK/MobileCenterCrashes/Microsoft.Azure.Mobile.Crashes/Properties/AssemblyInfo.cs
@@ -25,5 +25,5 @@ using System.Reflection;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("0.2.2.0")]
-[assembly: AssemblyInformationalVersion("0.2.2-SNAPSHOT")]
+[assembly: AssemblyFileVersion(".0")]
+[assembly: AssemblyInformationalVersion("-SNAPSHOT")]

--- a/SDK/MobileCenterCrashes/Microsoft.Azure.Mobile.Crashes/Properties/AssemblyInfo.cs
+++ b/SDK/MobileCenterCrashes/Microsoft.Azure.Mobile.Crashes/Properties/AssemblyInfo.cs
@@ -25,5 +25,5 @@ using System.Reflection;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion(".0")]
-[assembly: AssemblyInformationalVersion("-SNAPSHOT")]
+[assembly: AssemblyFileVersion("0.3.0.0")]
+[assembly: AssemblyInformationalVersion("0.3.0-SNAPSHOT")]

--- a/build.cake
+++ b/build.cake
@@ -41,14 +41,6 @@ var MOBILECENTER_MODULES = new [] {
 	new MobileCenterModule("mobile-center-crashes-release.aar", "MobileCenterCrashes.framework.zip", "SDK/MobileCenterCrashes/Microsoft.Azure.Mobile.Crashes", "MobileCenterCrashes.nuspec")
 };
 
-
-// CrashReporter name and version
-var PL_CRASH_NAME = "PLCrashReporter-1.2";
-
-// URL for downloading PLCrashReporter framework
-var PL_CRASH_URL = "https://www.plcrashreporter.org/static/downloads/" + PL_CRASH_NAME + ".zip";
-
-
 // Task TARGET for build
 var TARGET = Argument("target", Argument("t", "Default"));
 
@@ -116,30 +108,6 @@ Task("Externals-Ios")
 	foreach (var file in files) {
 		MoveFile(file, "./externals/ios/" + file.GetFilename() + ".a");
 	}
-
-	// Download zip file containing PLCrashReporter framework
-	DownloadFile(PL_CRASH_URL, "./externals/ios/plcrashreporter.zip");
-	Unzip("./externals/ios/plcrashreporter.zip", "./externals/ios/");
-
-	// Copy the framework to a shallower location
-
-	var framework_binary_location = "./externals/ios/" + PL_CRASH_NAME + "/iOS Framework/CrashReporter.framework/Versions/A/CrashReporter";
-	var framework_dest_path = "./externals/ios/CrashReporter.framework";
-	CreateDirectory(framework_dest_path);
-	CopyFile(framework_binary_location, framework_dest_path + "/CrashReporter");
-
-	// Put the PLCrashReporter framework into the two apps that need it
-	var puppet_frameworks_directory = "./Apps/Contoso.iOS.Puppet/MobileCenterFrameworks";
-	var ios_puppet_framework_dir = puppet_frameworks_directory + "/CrashReporter.framework";
-	CreateDirectory(puppet_frameworks_directory);
-	CreateDirectory(ios_puppet_framework_dir);
-	CopyFile(framework_binary_location, ios_puppet_framework_dir + "/CrashReporter");
-
-	var forms_frameworks_directory = "./Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.iOS/MobileCenterFrameworks";
-	var ios_forms_framework_dir = forms_frameworks_directory + "/CrashReporter.framework";
-	CreateDirectory(forms_frameworks_directory);
-	CreateDirectory(ios_forms_framework_dir);
-	CopyFile(framework_binary_location, ios_forms_framework_dir + "/CrashReporter");
 });
 
 // Create a common externals task depending on platform specific ones


### PR DESCRIPTION
As it turns out, we don't need to include the PLCrashReporter framework binary at all; the only support we provide is with lc++ and iscxx flags. This means that the iOS Crashes NuGet package does not need to create the MobileCenterFrameworks folder at all. This PR prevents PLCrashReporter framework from being downloaded and updates the MobileCenterCrashes.a binary properties so it doesn't link with it.