### PR TITLE
Add null-check to GetErrorAttachment callbacks

### DIFF
--- a/SDK/MobileCenterCrashes/Microsoft.Azure.Mobile.Crashes.Android/AndroidCrashListener.cs
+++ b/SDK/MobileCenterCrashes/Microsoft.Azure.Mobile.Crashes.Android/AndroidCrashListener.cs
@@ -22,7 +22,12 @@
 
             var report = ErrorReportCache.GetErrorReport(androidReport);
             var attachment = _owner.GetErrorAttachment(report);
-            return attachment.internalAttachment;
+            if (attachment != null)
+            {
+                return attachment.internalAttachment;
+            }
+
+            return null;
         }
 
         public void OnBeforeSending(AndroidErrorReport androidReport)

--- a/SDK/MobileCenterCrashes/Microsoft.Azure.Mobile.Crashes.iOS/CrashesDelegate.cs
+++ b/SDK/MobileCenterCrashes/Microsoft.Azure.Mobile.Crashes.iOS/CrashesDelegate.cs
@@ -31,7 +31,13 @@ namespace Microsoft.Azure.Mobile.Crashes
             }
               
             var report = ErrorReportCache.GetErrorReport(msReport);
-            return _owner.GetErrorAttachment(report).internalAttachment;
+            ErrorAttachment attachment = _owner.GetErrorAttachment(report);
+            if (attachment != null)
+            {
+                return attachment.internalAttachment;
+            }
+
+            return null;
          }
 
         public override void CrashesWillSendErrorReport(MSCrashes crashes, MSErrorReport msReport)


### PR DESCRIPTION
We crash if the user implements GetErrorAttachment and returns null- this PR fixes that.