### PR TITLE
Replace our signal handlers with mono signal handlers for SIGFPE

### DIFF
--- a/SDK/MobileCenterCrashes/Microsoft.Azure.Mobile.Crashes.iOS.Bindings/Extensions.cs
+++ b/SDK/MobileCenterCrashes/Microsoft.Azure.Mobile.Crashes.iOS.Bindings/Extensions.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Azure.Mobile.Crashes.iOS.Bindings
 
         private enum Signal
         {
+            SIGFPE = 8,
             SIGBUS = 10,
             SIGSEGV = 11
         }
@@ -33,19 +34,26 @@ namespace Microsoft.Azure.Mobile.Crashes.iOS.Bindings
             /* Allocate space to store the Mono handlers */
             IntPtr sigbus = Marshal.AllocHGlobal(512);
             IntPtr sigsegv = Marshal.AllocHGlobal(512);
+            IntPtr sigfpe = Marshal.AllocHGlobal(512);
 
-            /* Store Mono's SIGSEGV and SIGBUS handlers */
+            /* Store Mono's SIGSEGV, SIGBUS, and SIGFPE handlers */
             sigaction(Signal.SIGBUS, IntPtr.Zero, sigbus);
             sigaction(Signal.SIGSEGV, IntPtr.Zero, sigsegv);
+            sigaction(Signal.SIGFPE, IntPtr.Zero, sigfpe);
 
             /* Enable native SDK crash reporting library */
             MSWrapperExceptionManager.StartCrashReportingFromWrapperSdk();
 
-            /* Restore Mono SIGSEGV and SIGBUS handlers */
+            /* Restore Mono SIGSEGV, SIGBUS, and SIGFPE handlers */
             sigaction(Signal.SIGBUS, sigbus, IntPtr.Zero);
             sigaction(Signal.SIGSEGV, sigsegv, IntPtr.Zero);
+            sigaction(Signal.SIGFPE, sigfpe, IntPtr.Zero);
+
+            /* Release previously allocated space */
             Marshal.FreeHGlobal(sigbus);
             Marshal.FreeHGlobal(sigsegv);
+            Marshal.FreeHGlobal(sigfpe);
+
             return true;
         }
     }


### PR DESCRIPTION
Building an iOS app that supports certain architectures need to use the Mono handler for SIGFPE. This PR addresses that.