### PR TITLE
Fix returning null if calling MobileCenter.InstallId

### DIFF
--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.Droid/MainActivity.cs
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.Droid/MainActivity.cs
@@ -18,6 +18,7 @@ namespace Contoso.Forms.Puppet.Droid
             Xamarin.Forms.Forms.Init(this, savedInstanceState);
 
             MobileCenterLog.Assert(App.LogTag, "MobileCenter.Configured=" + MobileCenter.Configured);
+            MobileCenterLog.Assert(App.LogTag, "MobileCenter.InstallId (before configure)=" + MobileCenter.InstallId);
             MobileCenter.SetServerUrl("https://in-integration.dev.avalanch.es");
             MobileCenter.Configure("7f222d3c-0f5e-421b-93e7-f862c462e07e");
 

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.iOS/AppDelegate.cs
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.iOS/AppDelegate.cs
@@ -12,6 +12,7 @@ namespace Contoso.Forms.Puppet.iOS
             Xamarin.Forms.Forms.Init();
 
             MobileCenterLog.Assert(App.LogTag, "MobileCenter.Configured=" + MobileCenter.Configured);
+            MobileCenterLog.Assert(App.LogTag, "MobileCenter.InstallId (before configure)=" + MobileCenter.InstallId);
             MobileCenter.SetServerUrl("https://in-integration.dev.avalanch.es");
             MobileCenter.Configure("b889c4f2-9ac2-4e2e-ae16-dae54f2c5899");
 

--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.Android/MobileCenter.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.Android/MobileCenter.cs
@@ -146,7 +146,18 @@ namespace Microsoft.Azure.Mobile
         /// <remarks>
         /// The identifier is lost if clearing application data or uninstalling application.
         /// </remarks>
-        public static Guid InstallId => Guid.Parse(AndroidMobileCenter.InstallId.ToString());
+        public static Guid? InstallId
+        {
+            get
+            {
+                var installId = AndroidMobileCenter.InstallId;
+                if (installId != null)
+                {
+                    return Guid.Parse(installId.ToString());
+                }
+                return null;
+            }
+        }
 
         private static Application SetWrapperSdkAndGetApplication()
         {

--- a/SDK/MobileCenter/Microsoft.Azure.Mobile.iOS/MobileCenter.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile.iOS/MobileCenter.cs
@@ -150,7 +150,7 @@ namespace Microsoft.Azure.Mobile
         /// <remarks>
         /// The identifier is lost if clearing application data or uninstalling application.
         /// </remarks>
-        public static Guid InstallId => Guid.Parse(iOSMobileCenter.InstallId().ToString());
+        public static Guid? InstallId => Guid.Parse(iOSMobileCenter.InstallId().ToString());
 
         private static Class[] GetServices(IEnumerable<Type> services)
         {

--- a/SDK/MobileCenter/Microsoft.Azure.Mobile/MobileCenter.cs
+++ b/SDK/MobileCenter/Microsoft.Azure.Mobile/MobileCenter.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.Mobile
         /// <remarks>
         ///     The identifier is lost if clearing application data or uninstalling application.
         /// </remarks>
-        public static Guid InstallId { get; set; }
+        public static Guid? InstallId { get; set; }
 
         /// <summary>
         ///     Change the base URL (scheme + authority + port only) used to communicate with the backend.


### PR DESCRIPTION
Before configuring the sdk in Android.
Before fix it was crashing, this method has to be nullable.